### PR TITLE
Fix bug when using cache

### DIFF
--- a/lib/googlefonts.js
+++ b/lib/googlefonts.js
@@ -40,7 +40,7 @@ var singleton = function(apiKey, options) {
     // Check if we serve from cache or request the API
     var now = new Date() / 1000;
     if (self._cache && now - self._lastFetch < self.options.cacheLifeTime) {
-      callback(self._cache);
+      callback(undefined,self._cache);
       return self;
     }
     


### PR DESCRIPTION
The callback being called when a cached result is used improperly excluded the first error parameter.
